### PR TITLE
Auto speed control

### DIFF
--- a/Drive.java
+++ b/Drive.java
@@ -18,12 +18,13 @@ public class Drive {
 	private Timer timer;
 	private double rotationCompensation;
 	private double speedMultiplier = 1;
+	private boolean autoSpeedControlEnabled;
+	private boolean manualSpeedControlEnabled;
 	private static final double MIN_MULTIPLIER = 0.2;
 	private static final double MAX_MULTIPLIER = 1;
 	private static final double MULTIPLIER_INCREMENT = 0.1;
-	private static final double AUTO_MAX_SPEED_ACTIVATION_THRESHOLD = .5;
-	private static final double MAX_ELEVATOR_HEIGHT = 2400;
-	private static final double SPEED_CONTROL_RANGE_PERCENTAGE = .5;
+	private static final double MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE = 1200;
+	private static final double MAX_AUTO_SPEED_HEIGHT_ENCODER_VALUE = 2400;
 	private static final double P = 0.03;
 	private static final double I = 0.0;
 	private static final double D = 0.0;
@@ -49,34 +50,51 @@ public class Drive {
     	drive = new MecanumDrive(talonFrontLeft, talonRearLeft, talonFrontRight, talonRearRight);
     	driveController = new PIDController(P, I, D, gyro, driveOutput);
     	driveController.enable();
+    	manualSpeedControlEnabled = true;
+    	autoSpeedControlEnabled = false;
 	}
 	
 	public void ManualSetMaxSpeed(Controller controller) {
-    	if(controller.WasClicked(ButtonName.LB) && speedMultiplier > MIN_MULTIPLIER) {
-    		speedMultiplier -= MULTIPLIER_INCREMENT;
-    	} else if (controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
-    		speedMultiplier += MULTIPLIER_INCREMENT;
-    	}
-    	
-		drive.setMaxOutput(speedMultiplier);
+		if (manualSpeedControlEnabled) {
+	    	if(controller.WasClicked(ButtonName.LB) && speedMultiplier > MIN_MULTIPLIER) {
+	    		speedMultiplier -= MULTIPLIER_INCREMENT;
+	    	} else if (controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
+	    		speedMultiplier += MULTIPLIER_INCREMENT;
+	    	}
+	    	
+			drive.setMaxOutput(speedMultiplier);
+		}
     }
 	
 	public void AutoSetMaxSpeed(int encoderValue) {
-		if(encoderValue > 1200)
-			speedMultiplier = 1-(
-									(encoderValue-
-											(MAX_ELEVATOR_HEIGHT*AUTO_MAX_SPEED_ACTIVATION_THRESHOLD)
-									)/
-									(SPEED_CONTROL_RANGE_PERCENTAGE*
-											(MAX_ELEVATOR_HEIGHT/AUTO_MAX_SPEED_ACTIVATION_THRESHOLD))
-									);
-		else speedMultiplier = MAX_MULTIPLIER;
-		drive.setMaxOutput(speedMultiplier);
+		if(autoSpeedControlEnabled) {
+			if(encoderValue > MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)
+				speedMultiplier = MIN_MULTIPLIER + (
+														(encoderValue-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)*
+															(
+																	(MAX_MULTIPLIER-MIN_MULTIPLIER)/(MAX_AUTO_SPEED_HEIGHT_ENCODER_VALUE-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)
+															)
+													);
+			else speedMultiplier = MAX_MULTIPLIER;
+			drive.setMaxOutput(speedMultiplier);
+		}
 	}
 	
 	public void ResetPlayerAngle() {
 		gyro.reset();
 		driveController.setSetpoint(gyro.getAngle());
+	}
+	
+	public void EnableAutoSpeedControl(boolean enable) {
+		if(enable) {
+			autoSpeedControlEnabled = true;
+			manualSpeedControlEnabled = false;
+		}
+		else {
+			autoSpeedControlEnabled = false;
+			manualSpeedControlEnabled = true;
+			drive.setMaxOutput(MAX_MULTIPLIER);
+		}
 	}
 	
 	public void Update(double horizontal, double vertical, double rotation) {

--- a/Drive.java
+++ b/Drive.java
@@ -18,8 +18,6 @@ public class Drive {
 	private Timer timer;
 	private double rotationCompensation;
 	private double speedMultiplier = 1;
-	private boolean autoSpeedControlEnabled;
-	private boolean manualSpeedControlEnabled;
 	private static final double MIN_MULTIPLIER = 0.2;
 	private static final double MAX_MULTIPLIER = 1;
 	private static final double MULTIPLIER_INCREMENT = 0.1;
@@ -50,51 +48,28 @@ public class Drive {
     	drive = new MecanumDrive(talonFrontLeft, talonRearLeft, talonFrontRight, talonRearRight);
     	driveController = new PIDController(P, I, D, gyro, driveOutput);
     	driveController.enable();
-    	manualSpeedControlEnabled = true;
-    	autoSpeedControlEnabled = false;
 	}
 	
 	public void ManualSetMaxSpeed(Controller controller) {
-		if (manualSpeedControlEnabled) {
-	    	if(controller.WasClicked(ButtonName.LB) && speedMultiplier > MIN_MULTIPLIER) {
-	    		speedMultiplier -= MULTIPLIER_INCREMENT;
-	    	} else if (controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
-	    		speedMultiplier += MULTIPLIER_INCREMENT;
-	    	}
-	    	
-			drive.setMaxOutput(speedMultiplier);
-		}
+    	if(controller.WasClicked(ButtonName.LB) && speedMultiplier > MIN_MULTIPLIER) {
+    		speedMultiplier -= MULTIPLIER_INCREMENT;
+    	} else if (controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
+    		speedMultiplier += MULTIPLIER_INCREMENT;
+    	}
+    	
+		drive.setMaxOutput(speedMultiplier);
     }
 	
 	public void AutoSetMaxSpeed(int encoderValue) {
-		if(autoSpeedControlEnabled) {
-			if(encoderValue > MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)
-				speedMultiplier = MIN_MULTIPLIER + (
-														(encoderValue-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)*
-															(
-																	(MAX_MULTIPLIER-MIN_MULTIPLIER)/(MAX_AUTO_SPEED_HEIGHT_ENCODER_VALUE-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)
-															)
-													);
-			else speedMultiplier = MAX_MULTIPLIER;
-			drive.setMaxOutput(speedMultiplier);
-		}
+		if(encoderValue > MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)
+			speedMultiplier = MIN_MULTIPLIER + ((encoderValue-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)*((MAX_MULTIPLIER-MIN_MULTIPLIER)/(MAX_AUTO_SPEED_HEIGHT_ENCODER_VALUE-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)));
+		else speedMultiplier = MAX_MULTIPLIER;
+		drive.setMaxOutput(speedMultiplier);
 	}
 	
 	public void ResetPlayerAngle() {
 		gyro.reset();
 		driveController.setSetpoint(gyro.getAngle());
-	}
-	
-	public void EnableAutoSpeedControl(boolean enable) {
-		if(enable) {
-			autoSpeedControlEnabled = true;
-			manualSpeedControlEnabled = false;
-		}
-		else {
-			autoSpeedControlEnabled = false;
-			manualSpeedControlEnabled = true;
-			drive.setMaxOutput(MAX_MULTIPLIER);
-		}
 	}
 	
 	public void Update(double horizontal, double vertical, double rotation) {

--- a/Drive.java
+++ b/Drive.java
@@ -21,6 +21,9 @@ public class Drive {
 	private static final double MIN_MULTIPLIER = 0.2;
 	private static final double MAX_MULTIPLIER = 1;
 	private static final double MULTIPLIER_INCREMENT = 0.1;
+	private static final double AUTO_MAX_SPEED_ACTIVATION_THRESHOLD = .5;
+	private static final double MAX_ELEVATOR_HEIGHT = 2400;
+	private static final double SPEED_CONTROL_RANGE_PERCENTAGE = .5;
 	private static final double P = 0.03;
 	private static final double I = 0.0;
 	private static final double D = 0.0;
@@ -48,7 +51,7 @@ public class Drive {
     	driveController.enable();
 	}
 	
-	public void SetMaxSpeed(Controller controller) {
+	public void ManualSetMaxSpeed(Controller controller) {
     	if(controller.WasClicked(ButtonName.LB) && speedMultiplier > MIN_MULTIPLIER) {
     		speedMultiplier -= MULTIPLIER_INCREMENT;
     	} else if (controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
@@ -57,6 +60,19 @@ public class Drive {
     	
 		drive.setMaxOutput(speedMultiplier);
     }
+	
+	public void AutoSetMaxSpeed(int encoderValue) {
+		if(encoderValue > 1200)
+			speedMultiplier = 1-(
+									(encoderValue-
+											(MAX_ELEVATOR_HEIGHT*AUTO_MAX_SPEED_ACTIVATION_THRESHOLD)
+									)/
+									(SPEED_CONTROL_RANGE_PERCENTAGE*
+											(MAX_ELEVATOR_HEIGHT/AUTO_MAX_SPEED_ACTIVATION_THRESHOLD))
+									);
+		else speedMultiplier = MAX_MULTIPLIER;
+		drive.setMaxOutput(speedMultiplier);
+	}
 	
 	public void ResetPlayerAngle() {
 		gyro.reset();

--- a/Drive.java
+++ b/Drive.java
@@ -18,11 +18,9 @@ public class Drive {
 	private Timer timer;
 	private double rotationCompensation;
 	private double speedMultiplier = 1;
-	private static final double MIN_MULTIPLIER = 0.2;
-	private static final double MAX_MULTIPLIER = 1;
 	private static final double MULTIPLIER_INCREMENT = 0.1;
-	private static final double MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE = 1200;
-	private static final double MAX_AUTO_SPEED_HEIGHT_ENCODER_VALUE = 2400;
+	private static final double MIN_MULTIPLIER = 0.2;
+	private static final double MAX_MULTIPLIER = 1.0;
 	private static final double P = 0.03;
 	private static final double I = 0.0;
 	private static final double D = 0.0;
@@ -53,7 +51,7 @@ public class Drive {
 	public void ManualSetMaxSpeed(Controller controller) {
     	if(controller.WasClicked(ButtonName.LB) && speedMultiplier > MIN_MULTIPLIER) {
     		speedMultiplier -= MULTIPLIER_INCREMENT;
-    	} else if (controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
+    	} else if(controller.WasClicked(ButtonName.RB) && speedMultiplier < MAX_MULTIPLIER) {
     		speedMultiplier += MULTIPLIER_INCREMENT;
     	}
     	
@@ -61,9 +59,18 @@ public class Drive {
     }
 	
 	public void AutoSetMaxSpeed(int encoderValue) {
-		if(encoderValue > MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)
-			speedMultiplier = MIN_MULTIPLIER + ((encoderValue-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)*((MAX_MULTIPLIER-MIN_MULTIPLIER)/(MAX_AUTO_SPEED_HEIGHT_ENCODER_VALUE-MIN_AUTO_SPEED_HEIGHT_ENCODER_VALUE)));
-		else speedMultiplier = MAX_MULTIPLIER;
+		final double X0 = 0;
+		final double X1 = 2400;
+		final double Y1 = MIN_MULTIPLIER;
+		final double Y0 = MAX_MULTIPLIER;
+		if(encoderValue < X0) {
+			speedMultiplier = Y0;
+		} else if(encoderValue < X1) {
+			speedMultiplier = Y0 + ((encoderValue - X0) * ((Y1 - Y0) / (X1 - X0)));
+		} else {
+			speedMultiplier = Y1;
+		}
+		System.out.println(encoderValue + ", " + speedMultiplier);
 		drive.setMaxOutput(speedMultiplier);
 	}
 	

--- a/Elevator.java
+++ b/Elevator.java
@@ -17,7 +17,7 @@ public class Elevator {
 	
 	private static final int ENCODER_VALUE_NONE = -1;
 	private static final int ENCODER_VALUE_SCALE = 2400;
-	private static final int ENCODER_VALUE_SWITCH = 600;
+	private static final int ENCODER_VALUE_SWITCH = 1000;
 	private static final int ENCODER_VALUE_BOTTOM = 0;
 	private static final double P = 0.003;
 	private static final double I = 0.0;

--- a/Elevator.java
+++ b/Elevator.java
@@ -96,4 +96,8 @@ public class Elevator {
 	public boolean isCalibrating() {
 		return calibrating;
 	}
+	
+	public int getEncoderValue() {
+		return encoder.get();
+	}
 }

--- a/Robot.java
+++ b/Robot.java
@@ -20,6 +20,7 @@ public class Robot extends IterativeRobot {
 	Controller controllerElevator;
 	Controller controllerTilt;
 	Controller controllerDrive;
+	Controller controllerSpeed;
 	Switchboard switchboard = new Switchboard(2);
 	Drive drive = new Drive(4, 7, 10, 3);
 	Autonomous auto;
@@ -91,7 +92,8 @@ public class Robot extends IterativeRobot {
 		controllerClaw = controller0;
 		controllerDrive = controller0;
 		controllerElevator = controller1;
-		controllerTilt = controller0;
+		controllerTilt = controller1;
+		controllerSpeed = controller1;
 		
 		drive.ResetPlayerAngle();
 		elevator.EnablePID();
@@ -176,16 +178,19 @@ public class Robot extends IterativeRobot {
 		
 		elevator.CheckCalibration();
 		
+		// Speed Control Section
+		
+		drive.EnableAutoSpeedControl(controllerSpeed.IsToggled(ButtonName.Select));
+		
+		drive.ManualSetMaxSpeed(controllerSpeed);
+		
+		drive.AutoSetMaxSpeed(elevator.getEncoderValue());
 		
 		// Drive Section
 		
 		if(controllerDrive.WasClicked(Controller.ButtonName.B)) {
 			drive.ResetPlayerAngle();
 		}
-		
-		drive.ManualSetMaxSpeed(controller1);
-		
-		drive.AutoSetMaxSpeed(elevator.getEncoderValue());
 		
 		double horizontal = controllerDrive.GetValue(AnalogName.LeftJoyX);		
 		double vertical = -controllerDrive.GetValue(AnalogName.LeftJoyY);

--- a/Robot.java
+++ b/Robot.java
@@ -183,7 +183,9 @@ public class Robot extends IterativeRobot {
 			drive.ResetPlayerAngle();
 		}
 		
-		drive.SetMaxSpeed(controller1);
+		drive.ManualSetMaxSpeed(controller1);
+		
+		drive.AutoSetMaxSpeed(elevator.getEncoderValue());
 		
 		double horizontal = controllerDrive.GetValue(AnalogName.LeftJoyX);		
 		double vertical = -controllerDrive.GetValue(AnalogName.LeftJoyY);

--- a/Robot.java
+++ b/Robot.java
@@ -180,11 +180,9 @@ public class Robot extends IterativeRobot {
 		
 		// Speed Control Section
 		
-		drive.EnableAutoSpeedControl(controllerSpeed.IsToggled(ButtonName.Select));
-		
-		drive.ManualSetMaxSpeed(controllerSpeed);
-		
-		drive.AutoSetMaxSpeed(elevator.getEncoderValue());
+		if(controllerSpeed.IsToggled(ButtonName.Select))
+			drive.AutoSetMaxSpeed(elevator.getEncoderValue());
+		else drive.ManualSetMaxSpeed(controllerSpeed);
 		
 		// Drive Section
 		


### PR DESCRIPTION
Added automatic speed control feature, which is disabled by default. Operators can either increase/decrease max speed manually, or switch to automatic mode by pressing the 'Select' button on the operator controller. Auto speed control mode will slow speed automatically as elevator increases in height, to a minimum of 20% speed.